### PR TITLE
chore(update-packages): add support of release-it 18 and 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
         "slackify-markdown": "^4.3.1"
       },
       "devDependencies": {
-        "@release-it/conventional-changelog": "^8.0.0",
+        "@release-it/conventional-changelog": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "bron": "^2.0.3",
-        "release-it": "^17.0.0",
+        "release-it": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "sinon": "^15.0.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "bugs": "https://github.com/lightness/release-it-slack-notification-plugin/issues",
   "author": "Uladzimir Aleshka",
   "devDependencies": {
-    "@release-it/conventional-changelog": "^8.0.0",
+    "@release-it/conventional-changelog": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "bron": "^2.0.3",
-    "release-it": "^17.0.0",
+    "release-it": "^17.0.0 || ^18.0.0 || ^19.0.0",
     "sinon": "^15.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Added the possibility to use newer versions of release-it package. 